### PR TITLE
Fix: gists search wasn't working correctly searching for filename or description

### DIFF
--- a/main.py
+++ b/main.py
@@ -307,8 +307,8 @@ class GitHubExtension(Extension):
 
             desc = gist['description'] or ""
 
-            if query and query not in desc.lower(
-            ) or query not in gist['filename'].lower():
+            if query and (query not in desc.lower(
+            ) and query not in gist['filename'].lower()):
                 continue
 
             items.append(


### PR DESCRIPTION
An example:

Filename: gist1.txt
Description: A terraform snippet

Search for "terra" ... no result.

Fixed the logic, so searches both filenames and description. Next PR, I may update it to search gist contents too (yeah, I know I'd have to add them to the cache). Let me know what you think in the comments.

Thanks