### PR TITLE
[Bugfix] Fix list of all starred repos when one of them has a null description

### DIFF
--- a/main.py
+++ b/main.py
@@ -417,7 +417,7 @@ class GitHubExtension(Extension):
             items.append(
                 ExtensionResultItem(icon='images/icon.png',
                                     name=repo['name'],
-                                    description=repo['description'],
+                                    description=repo['description'] or "",
                                     on_enter=OpenUrlAction(repo['url']),
                                     on_alt_enter=CopyToClipboardAction(
                                         repo['url'])))


### PR DESCRIPTION
With the `gh starred` command and no further arguments, the script would crash when one of the repos would have a `None` description because Ulauncher can't take a `None` description.

With this simple fix, I'm able to successfully run `gh starred`.