### PR TITLE
Fix requirement format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pygithub=~1.55
+pygithub~=1.55
 requests


### PR DESCRIPTION
The format of the requirement was not correct. There is no `=~` it should be `~=` if that is what was intended